### PR TITLE
Fix for undefined name 'bid'

### DIFF
--- a/privacy_services_management/tcc_services.py
+++ b/privacy_services_management/tcc_services.py
@@ -304,7 +304,7 @@ command with the `--forceroot` option:
         # Disable the application for the given service.
         # The 'prompt_count' must be 1 or else the system will ask the user
         # anyway. This is the only time it seems to really matter.
-        values = (available_services[service][0], bid)
+        values = (available_services[service][0], target)
         c.execute('SELECT count(*) FROM access WHERE service IS ? and client IS ?', values)
         count = c.fetchone()[0]
         if count:


### PR DESCRIPTION
Ok, this should do it.

```
python privacy_services_manager.py disable contacts Toast
INFO: ################################################################################
Privacy Services Manager, version 1.6.5

    service:  contacts
    action:   disable
    app(s):   ['Toast']
    user:     N/A
    template: False
    language: N/A

INFO: Set to modify local permissions for user 'cda' at '/Users/cda/Library/Application Support/com.apple.TCC/TCC.db'.
INFO: Set to modify global permissions for all users at '/Library/Application Support/com.apple.TCC/TCC.db'.
INFO: Disabling 'com.roxio.Toast' in service 'contacts'...
ERROR: NameError: global name 'bid' is not defined
```